### PR TITLE
Fix compile bug on APPLE for rtl_test.c

### DIFF
--- a/src/rtl_test.c
+++ b/src/rtl_test.c
@@ -162,8 +162,8 @@ static int ppm_gettime(struct time_generic *tg)
 	struct timeval tv;
 
 	rv = gettimeofday(&tv, NULL);
-	ts->tv_sec = tv.tv_sec;
-	ts->tv_nsec = tv.tv_usec * 1000;
+	tg->tv_sec = tv.tv_sec;
+	tg->tv_nsec = tv.tv_usec * 1000;
 #endif
 	return rv;
 }


### PR DESCRIPTION
rtl_test.c has a compile error when built on a Mac. This change fixes the error and I have tested that rtl_test then bulds and runs on the Mac. Change ts (structure variable) to tg pointer on line 165 and 166
