### PR TITLE
fix typo that causes compile error on Mac OS

### DIFF
--- a/src/rtl_test.c
+++ b/src/rtl_test.c
@@ -162,8 +162,8 @@ static int ppm_gettime(struct time_generic *tg)
 	struct timeval tv;
 
 	rv = gettimeofday(&tv, NULL);
-	ts->tv_sec = tv.tv_sec;
-	ts->tv_nsec = tv.tv_usec * 1000;
+	tg->tv_sec = tv.tv_sec;
+	tg->tv_nsec = tv.tv_usec * 1000;
 #endif
 	return rv;
 }


### PR DESCRIPTION
In the `ppm_gettime()` function, there is a conditionally-compiled section that gets the current time in different ways based on platform. In the section for Mac OS, there is a typo in the name of the variable that the results are being assigned to, causing compilation to fail.