### PR TITLE
Fix compilation of rtl_test.c on Mac OS X

### DIFF
--- a/src/rtl_test.c
+++ b/src/rtl_test.c
@@ -152,9 +152,10 @@ static void underrun_test(unsigned char *buf, uint32_t len, int mute)
 static int ppm_gettime(struct time_generic *tg)
 {
 	int rv = ENOSYS;
-	struct timespec ts;
 
 #ifdef __unix__
+	struct timespec ts;
+
 	rv = clock_gettime(CLOCK_MONOTONIC, &ts);
 	tg->tv_sec = ts.tv_sec;
 	tg->tv_nsec = ts.tv_nsec;
@@ -162,8 +163,8 @@ static int ppm_gettime(struct time_generic *tg)
 	struct timeval tv;
 
 	rv = gettimeofday(&tv, NULL);
-	ts->tv_sec = tv.tv_sec;
-	ts->tv_nsec = tv.tv_usec * 1000;
+	tg->tv_sec = tv.tv_sec;
+	tg->tv_nsec = tv.tv_usec * 1000;
 #endif
 	return rv;
 }


### PR DESCRIPTION
- Fix typo whereby the result was being stored in a local struct instead of a parameter
- Move struct timespec to #ifdef **unix**
