### PR TITLE
added sync output mode

### DIFF
--- a/include/rtl-sdr.h
+++ b/include/rtl-sdr.h
@@ -216,6 +216,15 @@ RTLSDR_API int rtlsdr_get_tuner_gains(rtlsdr_dev_t *dev, int *gains);
 RTLSDR_API int rtlsdr_set_tuner_gain(rtlsdr_dev_t *dev, int gain);
 
 /*!
+ * Set the bandwidth for the device.
+ *
+ * \param dev the device handle given by rtlsdr_open()
+ * \param bw bandwidth in Hz. Zero means automatic BW selection.
+ * \return 0 on success
+ */
+RTLSDR_API int rtlsdr_set_tuner_bandwidth(rtlsdr_dev_t *dev, uint32_t bw);
+
+/*!
  * Get actual gain the device is configured to.
  *
  * \param dev the device handle given by rtlsdr_open()

--- a/include/tuner_r82xx.h
+++ b/include/tuner_r82xx.h
@@ -115,5 +115,6 @@ int r82xx_standby(struct r82xx_priv *priv);
 int r82xx_init(struct r82xx_priv *priv);
 int r82xx_set_freq(struct r82xx_priv *priv, uint32_t freq);
 int r82xx_set_gain(struct r82xx_priv *priv, int set_manual_gain, int gain);
+int r82xx_set_bandwidth(struct r82xx_priv *priv, int bandwidth,  uint32_t rate);
 
 #endif

--- a/rtl-sdr.rules
+++ b/rtl-sdr.rules
@@ -72,6 +72,9 @@ SUBSYSTEMS=="usb", ATTRS{idVendor}=="1554", ATTRS{idProduct}=="5020", MODE:="066
 # Astrometa DVB-T/DVB-T2 (R828D)
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="15f4", ATTRS{idProduct}=="0131", MODE:="0666"
 
+# HanfTek DAB+FM+DVB-T
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="15f4", ATTRS{idProduct}=="0133", MODE:="0666"
+
 # Compro Videomate U620F (E4000)
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="185b", ATTRS{idProduct}=="0620", MODE:="0666"
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,10 +17,11 @@
 # the Free Software Foundation, Inc., 51 Franklin Street,
 # Boston, MA 02110-1301, USA.
 
-########################################################################
-# Setup library
-########################################################################
-add_library(rtlsdr_shared SHARED
+MACRO(RTLSDR_APPEND_SRCS)
+    LIST(APPEND rtlsdr_srcs ${ARGV})
+ENDMACRO(RTLSDR_APPEND_SRCS)
+
+RTLSDR_APPEND_SRCS(
     librtlsdr.c
     tuner_e4k.c
     tuner_fc0012.c
@@ -29,24 +30,44 @@ add_library(rtlsdr_shared SHARED
     tuner_r82xx.c
 )
 
-target_link_libraries(rtlsdr_shared
-    ${LIBUSB_LIBRARIES}
-)
+########################################################################
+# Set up Windows DLL resource files
+########################################################################
+IF(MSVC)
+    include(${CMAKE_SOURCE_DIR}/cmake/Modules/Version.cmake)
 
+    configure_file(
+        ${CMAKE_CURRENT_SOURCE_DIR}/rtlsdr.rc.in
+        ${CMAKE_CURRENT_BINARY_DIR}/rtlsdr.rc
+    @ONLY)
+
+    RTLSDR_APPEND_SRCS(${CMAKE_CURRENT_BINARY_DIR}/rtlsdr.rc)
+ENDIF(MSVC)
+
+########################################################################
+# Setup shared library variant
+########################################################################
+add_library(rtlsdr_shared SHARED ${rtlsdr_srcs})
+target_link_libraries(rtlsdr_shared ${LIBUSB_LIBRARIES})
 set_target_properties(rtlsdr_shared PROPERTIES DEFINE_SYMBOL "rtlsdr_EXPORTS")
 set_target_properties(rtlsdr_shared PROPERTIES OUTPUT_NAME rtlsdr)
 set_target_properties(rtlsdr_shared PROPERTIES SOVERSION ${MAJOR_VERSION})
 set_target_properties(rtlsdr_shared PROPERTIES VERSION ${LIBVER})
 
-add_library(rtlsdr_static STATIC
-    librtlsdr.c
-    tuner_e4k.c
-    tuner_fc0012.c
-    tuner_fc0013.c
-    tuner_fc2580.c
-    tuner_r82xx.c
-)
+########################################################################
+# Setup static library variant
+########################################################################
+add_library(rtlsdr_static STATIC ${rtlsdr_srcs})
+target_link_libraries(rtlsdr_static ${LIBUSB_LIBRARIES})
+set_property(TARGET rtlsdr_static APPEND PROPERTY COMPILE_DEFINITIONS "rtlsdr_STATIC" )
+if(NOT WIN32)
+# Force same library filename for static and shared variants of the library
+set_target_properties(rtlsdr_static PROPERTIES OUTPUT_NAME rtlsdr)
+endif()
 
+########################################################################
+# Setup libraries used in executables
+########################################################################
 add_library(convenience_static STATIC
     convenience/convenience.c
 )
@@ -58,17 +79,6 @@ add_library(libgetopt_static STATIC
 target_link_libraries(convenience_static
     rtlsdr_shared
 )
-endif()
-
-target_link_libraries(rtlsdr_static
-    ${LIBUSB_LIBRARIES}
-)
-
-set_property(TARGET rtlsdr_static APPEND PROPERTY COMPILE_DEFINITIONS "rtlsdr_STATIC" )
-
-if(NOT WIN32)
-# Force same library filename for static and shared variants of the library
-set_target_properties(rtlsdr_static PROPERTIES OUTPUT_NAME rtlsdr)
 endif()
 
 ########################################################################

--- a/src/librtlsdr.c
+++ b/src/librtlsdr.c
@@ -1298,14 +1298,16 @@ static rtlsdr_dongle_t *find_known_device(uint16_t vid, uint16_t pid)
 
 uint32_t rtlsdr_get_device_count(void)
 {
-	int i;
+	int i,r;
 	libusb_context *ctx;
 	libusb_device **list;
 	uint32_t device_count = 0;
 	struct libusb_device_descriptor dd;
 	ssize_t cnt;
 
-	libusb_init(&ctx);
+	r = libusb_init(&ctx);
+	if(r < 0)
+		return 0;
 
 	cnt = libusb_get_device_list(ctx, &list);
 
@@ -1325,7 +1327,7 @@ uint32_t rtlsdr_get_device_count(void)
 
 const char *rtlsdr_get_device_name(uint32_t index)
 {
-	int i;
+	int i,r;
 	libusb_context *ctx;
 	libusb_device **list;
 	struct libusb_device_descriptor dd;
@@ -1333,7 +1335,9 @@ const char *rtlsdr_get_device_name(uint32_t index)
 	uint32_t device_count = 0;
 	ssize_t cnt;
 
-	libusb_init(&ctx);
+	r = libusb_init(&ctx);
+	if(r < 0)
+		return "";
 
 	cnt = libusb_get_device_list(ctx, &list);
 
@@ -1373,7 +1377,9 @@ int rtlsdr_get_device_usb_strings(uint32_t index, char *manufact,
 	uint32_t device_count = 0;
 	ssize_t cnt;
 
-	libusb_init(&ctx);
+	r = libusb_init(&ctx);
+	if(r < 0)
+		return r;
 
 	cnt = libusb_get_device_list(ctx, &list);
 
@@ -1447,7 +1453,11 @@ int rtlsdr_open(rtlsdr_dev_t **out_dev, uint32_t index)
 	memset(dev, 0, sizeof(rtlsdr_dev_t));
 	memcpy(dev->fir, fir_default, sizeof(fir_default));
 
-	libusb_init(&dev->ctx);
+	r = libusb_init(&dev->ctx);
+	if(r < 0){
+		free(dev);
+		return -1;
+	}
 
 	dev->dev_lost = 1;
 

--- a/src/librtlsdr.c
+++ b/src/librtlsdr.c
@@ -329,6 +329,7 @@ static rtlsdr_dongle_t known_devices[] = {
 	{ 0x0ccd, 0x00e0, "Terratec NOXON DAB/DAB+ USB dongle (rev 2)" },
 	{ 0x1554, 0x5020, "PixelView PV-DT235U(RN)" },
 	{ 0x15f4, 0x0131, "Astrometa DVB-T/DVB-T2" },
+	{ 0x15f4, 0x0133, "HanfTek DAB+FM+DVB-T" },
 	{ 0x185b, 0x0620, "Compro Videomate U620F"},
 	{ 0x185b, 0x0650, "Compro Videomate U650F"},
 	{ 0x185b, 0x0680, "Compro Videomate U680F"},

--- a/src/librtlsdr.c
+++ b/src/librtlsdr.c
@@ -354,7 +354,7 @@ static rtlsdr_dongle_t known_devices[] = {
 	{ 0x1f4d, 0xd803, "PROlectrix DV107669" },
 };
 
-#define DEFAULT_BUF_NUMBER	15
+#define DEFAULT_BUF_NUMBER	1
 #define DEFAULT_BUF_LENGTH	(16 * 32 * 512)
 
 #define DEF_RTL_XTAL_FREQ	28800000

--- a/src/rtl_adsb.c
+++ b/src/rtl_adsb.c
@@ -45,7 +45,9 @@
 
 #ifdef _WIN32
 #define sleep Sleep
+#if defined(_MSC_VER) && (_MSC_VER < 1800)
 #define round(x) (x > 0.0 ? floor(x + 0.5): ceil(x - 0.5))
+#endif
 #endif
 
 #define ADSB_RATE			2000000

--- a/src/rtl_fm.c
+++ b/src/rtl_fm.c
@@ -62,7 +62,7 @@
 #include <io.h>
 #include "getopt/getopt.h"
 #define usleep(x) Sleep(x/1000)
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && (_MSC_VER < 1800)
 #define round(x) (x > 0.0 ? floor(x + 0.5): ceil(x - 0.5))
 #endif
 #define _USE_MATH_DEFINES
@@ -271,7 +271,7 @@ int cic_9_tables[][10] = {
 	{9, -199, -362, 5303, -25505, 77489, -25505, 5303, -362, -199},
 };
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && (_MSC_VER < 1800)
 double log2(double n)
 {
 	return log(n) / log(2.0);

--- a/src/rtl_power.c
+++ b/src/rtl_power.c
@@ -53,7 +53,7 @@
 #include <io.h>
 #include "getopt/getopt.h"
 #define usleep(x) Sleep(x/1000)
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && (_MSC_VER < 1800)
 #define round(x) (x > 0.0 ? floor(x + 0.5): ceil(x - 0.5))
 #endif
 #define _USE_MATH_DEFINES
@@ -220,7 +220,7 @@ int cic_9_tables[][10] = {
 	{9, -199, -362, 5303, -25505, 77489, -25505, 5303, -362, -199},
 };
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && (_MSC_VER < 1800)
 double log2(double n)
 {
 	return log(n) / log(2.0);

--- a/src/rtlsdr.rc.in
+++ b/src/rtlsdr.rc.in
@@ -1,0 +1,34 @@
+
+#include <afxres.h>
+
+VS_VERSION_INFO VERSIONINFO
+  FILEVERSION 0,0,0,0
+  PRODUCTVERSION 0,0,0,0
+  FILEFLAGSMASK 0x3fL
+#ifndef NDEBUG
+  FILEFLAGS 0x0L
+#else
+  FILEFLAGS 0x1L
+#endif
+  FILEOS VOS__WINDOWS32
+  FILETYPE VFT_DLL
+  FILESUBTYPE VFT2_DRV_INSTALLABLE
+  BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+      BLOCK "040904b0"
+      BEGIN
+        VALUE "FileDescription", "osmocom rtl-sdr"
+        VALUE "FileVersion", "@VERSION@"
+        VALUE "InternalName", "rtl-sdr.dll"
+        VALUE "LegalCopyright", "Licensed under GPLv2"
+        VALUE "OriginalFilename", "rtl-sdr.dll"
+        VALUE "ProductName", "osmocom rtl-sdr"
+        VALUE "ProductVersion", "@VERSION@"
+      END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+      VALUE "Translation", 0x409, 1200
+    END
+  END

--- a/src/tuner_e4k.c
+++ b/src/tuner_e4k.c
@@ -64,11 +64,13 @@ static const uint8_t width2mask[] = {
  */
 static int e4k_reg_write(struct e4k_state *e4k, uint8_t reg, uint8_t val)
 {
+	int r;
 	uint8_t data[2];
 	data[0] = reg;
 	data[1] = val;
 
-	return rtlsdr_i2c_write_fn(e4k->rtl_dev, e4k->i2c_addr, data, 2);
+	r = rtlsdr_i2c_write_fn(e4k->rtl_dev, e4k->i2c_addr, data, 2);
+	return r == 2 ? 0 : -1;
 }
 
 /*! \brief Read a register of the tuner chip


### PR DESCRIPTION
By using the -S switch, you enable sync output mode.

This will help eliminate the "Failed to submit transfer #!" error when trying to use more than four usb RTL-SDR receivers.

Based on rtl_test sync mode.